### PR TITLE
Fix Kirkstone fetch error

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,9 +8,9 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-PV = "v2.0.0"
-SRC_URI = "git://git@github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=ssh;name=WanManager;tag=${PV}"
-SRCREV = "${PV}"
+PV = "${RDK_RELEASE}+git${SRCPV}"
+SRC_URI = "git://git@github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager"
+SRCREV = "v2.0.0"
 
 
 SRCREV_FORMAT = "WanManager"


### PR DESCRIPTION
The error is:
ERROR: rdk-wanmanager-v2.0.0-r0 do_fetch: Bitbake Fetcher Error: FetchError(Recipe uses a floating tag/branch 'v2.0.0' for repo 'github.com/rdkcentral/RdkWanManager.git' without a fixed SRCREV yet doesn't call bb.fetch2.get_srcrev() (use SRCPV in PV for OE)., None)