### PR TITLE
RDKB-55279 : halinterface cm_hal.h replaced with rdkb-halif-cm

### DIFF
--- a/recipes-ccsp/ccsp/rdk-ppp-manager.bb
+++ b/recipes-ccsp/ccsp/rdk-ppp-manager.bb
@@ -4,7 +4,7 @@ LICENSE = "Apache-2.0"
 
 LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
-DEPENDS = "ccsp-common-library dbus rdk-logger utopia halinterface libunpriv"
+DEPENDS = "ccsp-common-library dbus rdk-logger utopia halinterface libunpriv rdkb-halif-cm"
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 


### PR DESCRIPTION
[RDKB-55279](https://ccp.sys.comcast.net/browse/RDKB-55279) : halinterface cm_hal.h replaced with rdkb-halif-cm

Reason for change: Removing cm_hal.h file from "halinteface" and using the cm_hal.h file from "rdkb-halif-cm" to fetch the header file from opensource github.

Test Procedure: Build should be passed without any issue