### PR TITLE
CMFSUPPORT-1790 : Open sourcing IPOE health check component.

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,7 +8,7 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v2.2.0"
+GIT_TAG = "v2.3.0"
 SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 

--- a/recipes-ccsp/ccsp/rdkgponmanager.bb
+++ b/recipes-ccsp/ccsp/rdkgponmanager.bb
@@ -7,7 +7,7 @@ DEPENDS = "ccsp-common-library dbus rdk-logger utopia hal-platform json-hal-lib"
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v1.0.0"
+GIT_TAG = "v1.1.0"
 SRC_URI = "git://github.com/rdkcentral/RdkGponManager.git;branch=main;protocol=https;name=GponManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 EXTRA_OECONF_append  = " --with-ccsp-platform=bcm --with-ccsp-arch=arm "

--- a/recipes-support/ipoe-health-check/ipoe-health-check.bb
+++ b/recipes-support/ipoe-health-check/ipoe-health-check.bb
@@ -1,0 +1,30 @@
+SUMMARY = "IPoE Health Check component"
+
+LICENSE = "Apache-2.0"
+
+LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
+
+DEPENDS = "rdk-logger rdk-wanmanager"
+
+SRC_URI = "git://git@github.com/rdkcentral/IPOEHealthCheck.git;branch=main;protocol=https;name=IPoEHealthCheck"
+SRCREV_IPoEHealthCheck = "${AUTOREV}"
+SRCREV_FORMAT = ""
+
+PV = "${RDK_RELEASE}+git${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+inherit autotools pkgconfig
+
+CFLAGS_append = " \
+    -I${STAGING_INCDIR} \
+    -I${STAGING_INCDIR}/ccsp \
+    -I ${STAGING_INCDIR}/syscfg \
+    -I ${STAGING_INCDIR}/sysevent \
+    "
+
+CFLAGS_append += " ${@bb.utils.contains('DISTRO_FEATURES', 'feature_mapt', '-DFEATURE_MAPT', '', d)}"
+
+FILES_${PN} = " \
+   ${bindir}/ipoe_health_check \
+"

--- a/recipes-support/ipoe-health-check/ipoe-health-check.bb
+++ b/recipes-support/ipoe-health-check/ipoe-health-check.bb
@@ -6,11 +6,9 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 
 DEPENDS = "rdk-logger rdk-wanmanager"
 
-SRC_URI = "git://git@github.com/rdkcentral/IPOEHealthCheck.git;branch=main;protocol=https;name=IPoEHealthCheck"
-SRCREV_IPoEHealthCheck = "${AUTOREV}"
-SRCREV_FORMAT = ""
-
-PV = "${RDK_RELEASE}+git${SRCPV}"
+GIT_TAG = "v1.0.0"
+SRC_URI := "git://github.com/rdkcentral/IPOEHealthCheck.git;branch=main;protocol=https;name=IPoEHealthCheck;tag=${GIT_TAG}"
+PV = "${GIT_TAG}+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Reason for change:
Initial version of IPOEHealthCheck component movement from gerrit to github.

Test Procedure:
1. Build should pass

Risks: Medium