### PR TITLE
RDKBDEV-2735 : Enable -Werror and -Wall in RdkVlanManager.

### DIFF
--- a/recipes-ccsp/ccsp/rdk-vlanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-vlanmanager.bb
@@ -22,6 +22,9 @@ CFLAGS_append = " \
     -I${STAGING_INCDIR}/ccsp \
     -I ${STAGING_INCDIR}/syscfg \
     -I ${STAGING_INCDIR}/sysevent \
+    -Werror \
+    -Wall \
+    -Wno-format-truncation \
     "
 
 LDFLAGS += " -lprivilege"


### PR DESCRIPTION
Reason for change:
Enabling -Werror and -Wall in RdkVlanManager.

Test Procedure: Performed RdkVlanManager Sanity test.
Risks: None.