### PR TITLE
RDKBDEV-2733 : Enable -Werror and -Wall in RdkPppManager.

### DIFF
--- a/recipes-ccsp/ccsp/rdk-ppp-manager.bb
+++ b/recipes-ccsp/ccsp/rdk-ppp-manager.bb
@@ -27,6 +27,7 @@ CFLAGS_append = " \
     -I${STAGING_INCDIR}/utctx \
     -Wall \
     -Werror \
+    -Wno-format \
     "
 
 LDFLAGS += " -lprivilege"

--- a/recipes-ccsp/ccsp/rdk-ppp-manager.bb
+++ b/recipes-ccsp/ccsp/rdk-ppp-manager.bb
@@ -25,6 +25,8 @@ CFLAGS_append = " \
     -I ${STAGING_INCDIR}/sysevent \
     -I${STAGING_INCDIR}/utapi \
     -I${STAGING_INCDIR}/utctx \
+    -Wall \
+    -Werror \
     "
 
 LDFLAGS += " -lprivilege"


### PR DESCRIPTION
Reason for change:
Enabling -Werror and -Wall in RdkPppManager.

Test Procedure: Sanity test.
Risks: None.