### PR TITLE
DUMMY-0005: DNS Connectivity Check Feature Enabled RFC

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,9 +8,10 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v2.3.0"
-SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
-PV = "${GIT_TAG}+git${SRCPV}"
+#GIT_TAG = "v2.3.0"
+SRCREV = "${AUTOREV}"
+SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=L3-RFC;protocol=https;name=WanManager;"
+PV = "${RDK_RELEASE}+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -10,7 +10,7 @@ require recipes-ccsp/ccsp/ccsp_common.inc
 
 #GIT_TAG = "v2.3.0"
 SRCREV = "${AUTOREV}"
-SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=L3-RFC;protocol=https;name=WanManager;"
+SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=RDKB-56270-gtest;protocol=https;name=WanManager;"
 PV = "${RDK_RELEASE}+git${SRCPV}"
 
 S = "${WORKDIR}/git"

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -10,7 +10,7 @@ require recipes-ccsp/ccsp/ccsp_common.inc
 
 #GIT_TAG = "v2.3.0"
 SRCREV = "${AUTOREV}"
-SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=RDKB-56270-gtest;protocol=https;name=WanManager;"
+SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=L3-RFC;protocol=https;name=WanManager;"
 PV = "${RDK_RELEASE}+git${SRCPV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Reason for change: Control DNS connectivity check feature by RFC. RFC DML should be persistent on reboot and factory reset. Test Procedure:
1.)Test the RFC DML Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.DNSConnectivityCheck.Enable Risks: Medium
Priority: P1
Signed-off-by: kulvendra singh <kulvendra.singh@sky.uk>