### PR TITLE
RDKBDEV-2732 : RDKCOM-4907: Enable -Werror and -Wall in RdkGponManager.

### DIFF
--- a/recipes-ccsp/ccsp/rdkgponmanager.bb
+++ b/recipes-ccsp/ccsp/rdkgponmanager.bb
@@ -28,6 +28,9 @@ CFLAGS_append = " \
     -I${STAGING_INCDIR}/ccsp \
     -I ${STAGING_INCDIR}/syscfg \
     -I ${STAGING_INCDIR}/sysevent \
+    -Werror \
+    -Wall \
+    -Wno-error=switch \
     "
 CFLAGS_append  = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '-DFEATURE_RDKB_WAN_MANAGER', '', d)}"
 

--- a/recipes-ccsp/ccsp/rdkgponmanager.bb
+++ b/recipes-ccsp/ccsp/rdkgponmanager.bb
@@ -7,9 +7,10 @@ DEPENDS = "ccsp-common-library dbus rdk-logger utopia hal-platform json-hal-lib"
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v1.1.0"
-SRC_URI = "git://github.com/rdkcentral/RdkGponManager.git;branch=main;protocol=https;name=GponManager;tag=${GIT_TAG}"
-PV = "${GIT_TAG}+git${SRCPV}"
+#GIT_TAG = "v1.1.0"
+SRCREV = "${AUTOREV}"
+SRC_URI = "git://github.com/Sukanya673/RdkGponManager.git;branch=RDKBDEV-2732_Gpon;protocol=https;name=GponManager;"
+PV = "${RDK_RELEASE}+git${SRCPV}"
 EXTRA_OECONF_append  = " --with-ccsp-platform=bcm --with-ccsp-arch=arm "
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Reason for change:
Enabling -Werror and -Wall in RdkGponManager.

Test Procedure: Sanity test.
Risks: None.

Signed-off-by: K Sanjay Nayak <k-sanjay.nayak@t-systems.com>
(cherry picked from commit 988267fb3a8349d7080e7cf1d1ceb944e7de9218)