### PR TITLE
RDKB-56115 : HUB4 GRT cached builds are failing.

### DIFF
--- a/recipes-ccsp/ccsp/rdk-vlanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-vlanmanager.bb
@@ -6,7 +6,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 DEPENDS = "ccsp-common-library dbus rdk-logger utopia hal-platform libunpriv"
 
 require recipes-ccsp/ccsp/ccsp_common.inc
-SSTATE_SKIP_CREATION = "1"
 
 GIT_TAG = "v1.0.0"
 SRC_URI = "git://github.com/rdkcentral/RdkVlanBridgingManager.git;branch=main;protocol=https;name=VlanBridgingManager;tag=${GIT_TAG}"


### PR DESCRIPTION
Reason for change:
This is a regression of https://github.com/rdkcentral/meta-rdk-wan/pull/18 changes. Particulary due to SSTATE_SKIP_CREATION = "1". so this needs to be corrected

Test Procedure:
1. All products build should be passed.

Risks: Low