### PR TITLE
RDKB-55862:Create new WanManager version tag

### DIFF
--- a/recipes-ccsp/ccsp/rdk-ppp-manager.bb
+++ b/recipes-ccsp/ccsp/rdk-ppp-manager.bb
@@ -8,7 +8,7 @@ DEPENDS = "ccsp-common-library dbus rdk-logger utopia halinterface libunpriv"
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "RC1.1.0b"
+GIT_TAG = "v1.1.0"
 SRC_URI := "git://github.com/rdkcentral/RdkPppManager.git;branch=main;protocol=https;name=PppManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 

--- a/recipes-ccsp/ccsp/rdk-vlanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-vlanmanager.bb
@@ -7,7 +7,7 @@ DEPENDS = "ccsp-common-library dbus rdk-logger utopia hal-platform libunpriv"
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "RC1.1.0a"
+GIT_TAG = "v1.1.0"
 SRC_URI = "git://github.com/rdkcentral/RdkVlanBridgingManager.git;branch=main;protocol=https;name=VlanBridgingManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,7 +8,7 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "RC2.4.0c"
+GIT_TAG = "v2.4.0"
 SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 

--- a/recipes-ccsp/ccsp/rdkgponmanager.bb
+++ b/recipes-ccsp/ccsp/rdkgponmanager.bb
@@ -7,7 +7,7 @@ DEPENDS = "ccsp-common-library dbus rdk-logger utopia hal-platform json-hal-lib"
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "RC1.2.0a"
+GIT_TAG = "v1.2.0"
 SRC_URI = "git://github.com/rdkcentral/RdkGponManager.git;branch=main;protocol=https;name=GponManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 EXTRA_OECONF_append  = " --with-ccsp-platform=bcm --with-ccsp-arch=arm "


### PR DESCRIPTION
Reason for change: new version tags to release in stable2 , RdkWanManager:v2.4.0, RdkPppManager:v1.1.0,RdkGponManager:v1.2.0, RdkVlanBridgingManager:v1.1.0 Test Procedure:
1.)Test the list of commit between last and current version tag given above. Risks: Medium
Priority: P2
Signed-off-by: kulvendra singh <kulvendra.singh@sky.uk>