### PR TITLE
RDKB-57169:Upgrade Wan components from 1.4.0 to RC1.5.0a

### DIFF
--- a/recipes-ccsp/ccsp/rdk-vlanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-vlanmanager.bb
@@ -7,7 +7,7 @@ DEPENDS = "ccsp-common-library dbus rdk-logger utopia hal-platform libunpriv"
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v1.1.0"
+GIT_TAG = "RC1.2.0"
 SRC_URI = "git://github.com/rdkcentral/RdkVlanBridgingManager.git;branch=main;protocol=https;name=VlanBridgingManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,7 +8,7 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v2.4.0"
+GIT_TAG = "RC2.5.0a"
 SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 

--- a/recipes-ccsp/ccsp/rdkxdslmanager.bb
+++ b/recipes-ccsp/ccsp/rdkxdslmanager.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=175792518e4ac015ab6696d16c4f607e"
 DEPENDS = "ccsp-common-library dbus rdk-logger utopia json-hal-lib avro-c hal-platform libparodus libunpriv"
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v1.0.0"
+GIT_TAG = "RC1.1.0"
 SRC_URI = "git://github.com/rdkcentral/RdkXdslManager.git;branch=main;protocol=https;name=xDSLManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 


### PR DESCRIPTION
Reason for change: creating new tagged version for meta-rdk-wan with component tags: RdkWanManager: RC2.5.0a, RdkXdslManager:RC1.1.0 and RdkVlanAndBridgingManager:RC1.2.0 Test Procedure:
1.)Test the tickets which is merged under this tags of component. Risks: High
Priority: P1
Signed-off-by: kulvendra singh <kulvendra.singh@sky.uk>