### PR TITLE
RDKB-57254 : MAP-T Unification

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,7 +8,7 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=configurable_wan_interface_for_XB;protocol=https;name=WanManager;"
+SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=feature-MAPT-Unification;protocol=https;name=WanManager;"
 SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -34,6 +34,7 @@ CFLAGS_append  = " ${@bb.utils.contains('DISTRO_FEATURES', 'ipoe_health_check', 
 CFLAGS_append += " ${@bb.utils.contains('DISTRO_FEATURES', 'WanFailOverSupportEnable', ' -DWAN_FAILOVER_SUPPORTED', '', d)}"
 PACKAGES += "${@bb.utils.contains('DISTRO_FEATURES', 'gtestapp', '${PN}-gtest', '', d)}"
 
+EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'unified_mapt', '--enable-maptunificationsupport', '', d)}"
 # Define a variable to consolidate the check for MAPT features based on DISTRO_FEATURES
 MAPT_FEATURE_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'feature_mapt','true', bb.utils.contains('DISTRO_FEATURES', 'unified_mapt', 'true', 'false', d), d)}"
 

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -35,7 +35,7 @@ CFLAGS_append  = " ${@bb.utils.contains('DISTRO_FEATURES', 'ipoe_health_check', 
 CFLAGS_append += " ${@bb.utils.contains('DISTRO_FEATURES', 'WanFailOverSupportEnable', ' -DWAN_FAILOVER_SUPPORTED', '', d)}"
 PACKAGES += "${@bb.utils.contains('DISTRO_FEATURES', 'gtestapp', '${PN}-gtest', '', d)}"
 
-EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'unified_mapt', '--enable-maptunificationsupport', '', d)}"
+EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'WanManagerUnificationEnable', '--enable-wanunificationsupport', '', d)}"
 # Define a variable to consolidate the check for MAPT features based on DISTRO_FEATURES
 MAPT_FEATURE_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'feature_mapt','true', bb.utils.contains('DISTRO_FEATURES', 'unified_mapt', 'true', 'false', d), d)}"
 

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -35,13 +35,12 @@ CFLAGS_append += " ${@bb.utils.contains('DISTRO_FEATURES', 'WanFailOverSupportEn
 PACKAGES += "${@bb.utils.contains('DISTRO_FEATURES', 'gtestapp', '${PN}-gtest', '', d)}"
 
 # Define a variable to consolidate the check for MAPT features based on DISTRO_FEATURES
-#MAPT_FEATURE_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'feature_mapt','true', bb.utils.contains('DISTRO_FEATURES', 'nat46', 'true', 'false', d), d)}"
-MAPT_FEATURE_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'WanManagerUnificationEnable', bb.utils.contains('DISTRO_FEATURES', 'nat46', 'true', 'false', d), 'false', d) == 'true' or bb.utils.contains('DISTRO_FEATURES', 'feature_mapt', 'true', 'false', d) == 'true'}"
+MAPT_FEATURE_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'feature_mapt','true', bb.utils.contains('DISTRO_FEATURES', 'unified_mapt', 'true', 'false', d), d)}"
 
 # Use the variable in CFLAGS_append
-CFLAGS_append += " ${@'${MAPT_FEATURE_ENABLED}' == 'True' and '-DFEATURE_MAPT' or ''}"
-CFLAGS_append += " ${@'${MAPT_FEATURE_ENABLED}' == 'True' and '-DFEATURE_MAPT_DEBUG' or ''}"
-CFLAGS_append += " ${@'${MAPT_FEATURE_ENABLED}' == 'True' and '-DNAT46_KERNEL_SUPPORT' or ''}"
+CFLAGS_append += " ${@'${MAPT_FEATURE_ENABLED}' == 'true' and '-DFEATURE_MAPT' or ''}"
+CFLAGS_append += " ${@'${MAPT_FEATURE_ENABLED}' == 'true' and '-DFEATURE_MAPT_DEBUG' or ''}"
+CFLAGS_append += " ${@'${MAPT_FEATURE_ENABLED}' == 'true' and '-DNAT46_KERNEL_SUPPORT' or ''}"
 
 LDFLAGS += " -lprivilege -lpthread -lstdc++"
 
@@ -66,7 +65,7 @@ do_compile_prepend () {
     sed -i '2i <?define RBUS_BUILD_FLAG_ENABLE=True?>' ${S}/config/${XML_NAME}
     fi
 
-    if [ "${MAPT_FEATURE_ENABLED}" = "True" ]; then
+    if [ "${MAPT_FEATURE_ENABLED}" = "true" ]; then
         sed -i '2i <?define FEATURE_MAPT=True?>' ${S}/config/${XML_NAME}
     fi
 

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -11,7 +11,6 @@ require recipes-ccsp/ccsp/ccsp_common.inc
 SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=feature-MAPT-Unification;protocol=https;name=WanManager;"
 SRCREV = "${AUTOREV}"
 
-
 S = "${WORKDIR}/git"
 
 inherit autotools pkgconfig ${@bb.utils.contains("DISTRO_FEATURES", "kirkstone", "python3native", "pythonnative", d)}

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,7 +8,7 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "RC2.5.0b"
+GIT_TAG = "RC2.7.0a"
 SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,9 +8,8 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "RC2.5.0b"
-SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
-PV = "${GIT_TAG}+git${SRCPV}"
+SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=feature-MAPT-Unification;protocol=https;name=WanManager;"
+SRCREV = "${AUTOREV}"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,8 +8,9 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=feature-MAPT-Unification;protocol=https;name=WanManager;"
-SRCREV = "${AUTOREV}"
+GIT_TAG = "RC2.5.0b"
+SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
+PV = "${GIT_TAG}+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Reason for change:
Unify MAP-T handling from dibbler and PandM.
Move the unify MAP-T handling to Wan Manager.

Tag change: 
https://github.com/rdkcentral/RdkWanManager/compare/RC2.6.0a...RC2.7.0a
RDKCOM-5173 REFPLTB-3128: [TDK][AUTO][RPI4][CELLULAR MANAGER] Switching back to ethwan from cellular mode not working as expected by @ksaipr036 in https://github.com/rdkcentral/RdkWanManager/pull/80
RDKB-57254 : MAP-T Unification by @S-Parthiban-Selvaraj in https://github.com/rdkcentral/RdkWanManager/pull/72

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1

Change-Id: I30a9d7d67e17c3c25cc558bf56d3dc802a8712b5
