### PR TITLE
RDKBNETWOR-2 : Load DHCP Manager Data Models

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -56,7 +56,7 @@ do_compile_prepend () {
     fi
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'dhcp_manager', 'true', 'false', d)}; then
-        sed -i '2i <?define FEATURE_RDKB_DHCP_MANAGER=True?>' ${S}/config/RdkWanManager.xml
+        sed -i '2i <?define FEATURE_RDKB_DHCP_MANAGER=True?>' ${S}/config/${XML_NAME}
     fi
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'WanFailOverSupportEnable', 'true', 'false', d)}; then


### PR DESCRIPTION
Reason for change: Pointing to the wrong xml file due to which the DMs were not loading.
Test Procedure: Build the image and load the DHCPv4/DHCPv6 DMs.
Testing Done : Results are captured in RDKBNETWOR-2
Risks: None.