### PR TITLE
RDKB-58231 : Upgrade Wan components to RC1.8.0a.

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,7 +8,7 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "RC2.7.0a"
+GIT_TAG = "RC2.8.0a"
 SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 


### PR DESCRIPTION
Reason for change:
Upgrade Wan components to RC1.8.0a
Upgrading Wan Manager to RC2.8.0a Pre-release
What's Changed
RDKB-57439 : [XER10-UK] IPv6 Handling - Wan & Lan Management. by @LakshminarayananShenbagaraj in #88 Full Changelog: RC2.7.0a...RC2.8.0a

Test Procedure:
1. Build should work without any issue.

Risks: Low