### PR TITLE
RDKB-58416 :  Modify meta-rdk-wan recipe to dynamically select tags

### DIFF
--- a/recipes-ccsp/ccsp/rdk-ppp-manager.bb
+++ b/recipes-ccsp/ccsp/rdk-ppp-manager.bb
@@ -14,7 +14,7 @@ TAG_VERSION="1.2.0"
 # The GIT_TAG will be dynamically determined based on the TAG_VERSION.
 # The following code fetches the tag in the following priority order:
 # Example v2.7.0 -> RC2.7.0z -> RC2.7.0y -> ... -> RC2.7.0b -> RC2.7.0a
-GIT_TAG = "${@os.popen('git ls-remote --tags -q  https://github.com/rdkcentral/RdkPppManager.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split()[-1].split('/')[-1]}"
+GIT_TAG = "${@os.popen('git ls-remote --tags -q  https://github.com/rdkcentral/RdkPppManager.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split('\n')[-1].split('/')[-1]}"
 
 SRC_URI := "git://github.com/rdkcentral/RdkPppManager.git;branch=main;protocol=https;name=PppManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"

--- a/recipes-ccsp/ccsp/rdk-vlanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-vlanmanager.bb
@@ -13,7 +13,7 @@ TAG_VERSION="1.3.0"
 # The GIT_TAG will be dynamically determined based on the TAG_VERSION.
 # The following code fetches the tag in the following priority order:
 # Example v2.7.0 -> RC2.7.0z -> RC2.7.0y -> ... -> RC2.7.0b -> RC2.7.0a
-GIT_TAG = "${@os.popen('git ls-remote --tags -q  https://github.com/rdkcentral/RdkVlanBridgingManager.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split()[-1].split('/')[-1]}"
+GIT_TAG = "${@os.popen('git ls-remote --tags -q  https://github.com/rdkcentral/RdkVlanBridgingManager.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split('\n')[-1].split('/')[-1]}"
 
 SRC_URI = "git://github.com/rdkcentral/RdkVlanBridgingManager.git;branch=main;protocol=https;name=VlanBridgingManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"

--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -9,12 +9,12 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 require recipes-ccsp/ccsp/ccsp_common.inc
 
 # Set the component version here
-TAG_VERSION="2.8.0"
+TAG_VERSION="2.7.0"
 
 # The GIT_TAG will be dynamically determined based on the TAG_VERSION.
 # The following code fetches the tag in the following priority order:
 # Example v2.7.0 -> RC2.7.0z -> RC2.7.0y -> ... -> RC2.7.0b -> RC2.7.0a
-GIT_TAG = "${@os.popen('git ls-remote --tags -q https://github.com/rdkcentral/RdkWanManager.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split()[-1].split('/')[-1]}"
+GIT_TAG = "${@os.popen('git ls-remote --tags -q https://github.com/rdkcentral/RdkWanManager.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split('\n')[-1].split('/')[-1]}"
 
 SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"

--- a/recipes-ccsp/ccsp/rdkgponmanager.bb
+++ b/recipes-ccsp/ccsp/rdkgponmanager.bb
@@ -13,7 +13,7 @@ TAG_VERSION="1.3.0"
 # The GIT_TAG will be dynamically determined based on the TAG_VERSION.
 # The following code fetches the tag in the following priority order:
 # Example v2.7.0 -> RC2.7.0z -> RC2.7.0y -> ... -> RC2.7.0b -> RC2.7.0a
-GIT_TAG = "${@os.popen('git ls-remote --tags -q  https://github.com/rdkcentral/RdkGponManager.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split()[-1].split('/')[-1]}"
+GIT_TAG = "${@os.popen('git ls-remote --tags -q  https://github.com/rdkcentral/RdkGponManager.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split('\n')[-1].split('/')[-1]}"
 
 SRC_URI = "git://github.com/rdkcentral/RdkGponManager.git;branch=main;protocol=https;name=GponManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"

--- a/recipes-ccsp/ccsp/rdkxdslmanager.bb
+++ b/recipes-ccsp/ccsp/rdkxdslmanager.bb
@@ -12,7 +12,7 @@ TAG_VERSION="1.2.0"
 # The GIT_TAG will be dynamically determined based on the TAG_VERSION.
 # The following code fetches the tag in the following priority order:
 # Example v2.7.0 -> RC2.7.0z -> RC2.7.0y -> ... -> RC2.7.0b -> RC2.7.0a
-GIT_TAG = "${@os.popen('git ls-remote --tags -q  https://github.com/rdkcentral/RdkXdslManager.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split()[-1].split('/')[-1]}"
+GIT_TAG = "${@os.popen('git ls-remote --tags -q  https://github.com/rdkcentral/RdkXdslManager.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split('\n')[-1].split('/')[-1]}"
 
 SRC_URI = "git://github.com/rdkcentral/RdkXdslManager.git;branch=main;protocol=https;name=xDSLManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"

--- a/recipes-support/ipoe-health-check/ipoe-health-check.bb
+++ b/recipes-support/ipoe-health-check/ipoe-health-check.bb
@@ -12,7 +12,7 @@ TAG_VERSION="1.1.0"
 # The GIT_TAG will be dynamically determined based on the TAG_VERSION.
 # The following code fetches the tag in the following priority order:
 # Example v2.7.0 -> RC2.7.0z -> RC2.7.0y -> ... -> RC2.7.0b -> RC2.7.0a
-GIT_TAG = "${@os.popen('git ls-remote --tags -q  https://github.com/rdkcentral/IPOEHealthCheck.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split()[-1].split('/')[-1]}"
+GIT_TAG = "${@os.popen('git ls-remote --tags -q  https://github.com/rdkcentral/IPOEHealthCheck.git ' + ' v' + d.getVar('TAG_VERSION', True) + ' RC' + d.getVar('TAG_VERSION', True) + '[a-z]').read().strip().split('\n')[-1].split('/')[-1]}"
 
 SRC_URI := "git://github.com/rdkcentral/IPOEHealthCheck.git;branch=main;protocol=https;name=IPoEHealthCheck;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"


### PR DESCRIPTION
Reason for change:
Currently, the meta-rdk-wan BitBake recipe files have the tags configured statically. This requires manual changes and additional pull requests whenever there is a change in the RC tags (e.g., RC1.6.0a, RC1.6.0b, RC1.6.0c, etc.) or final versions (e.g., v1.6.0). The goal of this ticket is to implement a solution within the WAN component's recipe file that allows it to dynamically select the latest tags based on a specified version. This will eliminate the need for frequent updates to the BitBake files whenever a new tag or version is released, simplifying the release management process.

Test Procedure:
Should fecth the correct tag

Risks: none
Priority: P2

Change-Id: Id78c08b917d45f58f8def5ac3d2dec06000fd947