### PR TITLE
RDKB-58931: Removing RFC control for non-root processes

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,9 +8,8 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v2.6.0"
-SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
-PV = "${GIT_TAG}+git${SRCPV}"
+SRC_URI := "git://github.com/Lasya-Prakarsha-D-V/RdkWanManager.git;branch=topic/RDKB-58967;protocol=https;name=WanManager"
+SRCREV = "1514a110f67aae1cfc1401b369683ae393310b13"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Reason for change: Wanmanager processes are running in non-root with rfc control, removing rfc controlled code part
Test Procedure: Processes should not be able to switch back to root using RFC DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.NonRootSupport.Blocklist
Risks: Medium
Priority: P1