### PR TITLE
RDKB-59858 : Upgrade Wan components to v1.10.1

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,8 +8,8 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v2.10.0"
-SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=main;protocol=https;name=WanManager;tag=${GIT_TAG}"
+GIT_TAG = "v2.10.1"
+SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=releases/2.10.0-main;protocol=https;name=WanManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
New tags:
    Upgrade Wan components to v1.10.1

  Wan Manager
    Upgrade to  https://github.com/rdkcentral/RdkWanManager/releases/tag/v2.10.1
    RDKB-59877 : MAPT acceleration is not working ...

Change-Id: I181759f514355b0ff5b3ad99e9d91edb4fd58a22