### PR TITLE
RDKB-59858 : Upgrade Wan components to v1.10.2

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,7 +8,7 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v2.10.1"
+GIT_TAG = "v2.10.2"
 SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=releases/2.10.0-main;protocol=https;name=WanManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 


### PR DESCRIPTION
New tags:
    Upgrade Wan components to v1.10.1

  Wan Manager
    Upgrade to  https://github.com/rdkcentral/RdkWanManager/releases/tag/v2.10.2
    RDKB-59957 : [XB-MAPT] MTU Sizes Differ Between Release and Sprint Build…
    TCXB7-6967 :Fix for LAN mac leak when the device is scanning DOCSIS

Change-Id: I1c647c3f4ed3726453c2b2429308a5923fd77008