### PR TITLE
RDKBNETWOR-11: DhcpManager integration with WanManager (Wg network11 development)

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -41,6 +41,9 @@ EXTRA_OECONF_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'WanManagerUnifi
 # Define a variable to consolidate the check for MAPT features based on DISTRO_FEATURES
 MAPT_FEATURE_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'feature_mapt','true', bb.utils.contains('DISTRO_FEATURES', 'unified_mapt', 'true', 'false', d), d)}"
 
+# Flag for DHCPmanager conf
+EXTRA_OECONF += "${@bb.utils.contains("DISTRO_FEATURES", "dhcp_manager", " --enable-dhcp_manager=yes", " ",d)}"
+
 # Use the variable in CFLAGS_append
 CFLAGS_append += " ${@'${MAPT_FEATURE_ENABLED}' == 'true' and '-DFEATURE_MAPT' or ''}"
 CFLAGS_append += " ${@'${MAPT_FEATURE_ENABLED}' == 'true' and '-DFEATURE_MAPT_DEBUG' or ''}"


### PR DESCRIPTION
This pull request introduces a new configuration flag for enabling DHCP Manager in the `rdk-wanmanager.bb` recipe. The change ensures that the build system can conditionally enable DHCP Manager based on the presence of the `dhcp_manager` feature in `DISTRO_FEATURES`.

Key change:

* [`recipes-ccsp/ccsp/rdk-wanmanager.bb`](diffhunk://#diff-0563d462519725e53557b547ccfc610fda534ffa8e7e3e8a2487d077188be663R44-R46): Added a conditional flag (`--enable-dhcp_manager=yes`) to `EXTRA_OECONF` for enabling DHCP Manager based on the `dhcp_manager` feature in `DISTRO_FEATURES`.