### PR TITLE
RDKBDEV-3213: Moving /etc/WFO_enabled flag creation from mesh-agent to wanmanager

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -84,6 +84,11 @@ do_install_append () {
     ln -sf ${bindir}/wanmanager ${D}${exec_prefix}/rdk/wanmanager/wanmanager
     ln -sf ${bindir}/netmonitor ${D}${exec_prefix}/rdk/wanmanager/netmonitor
     install -m 644 ${S}/config/${XML_NAME} ${D}/usr/rdk/wanmanager/RdkWanManager.xml
+
+   if ${@bb.utils.contains('DISTRO_FEATURES', 'WanFailOverSupportEnable', 'true', 'false', d)}; then
+        install -d ${D}/etc
+        touch ${D}/etc/WFO_enabled
+   fi
 }
 
 
@@ -93,6 +98,8 @@ FILES_${PN} = " \
    ${exec_prefix}/rdk/wanmanager/RdkWanManager.xml \
    ${bindir}/* \
 "
+
+FILES_${PN} += " ${@bb.utils.contains('DISTRO_FEATURES', 'WanFailOverSupportEnable', '/etc/WFO_enabled', '', d)} "
 
 FILES_${PN}-dbg = " \
     ${exec_prefix}/rdk/wanmanager/.debug \


### PR DESCRIPTION
Reason for change: It was observed that /etc/WFO_enabled flag was created from mesh-agent Yocto recipe, instead from rdk-wanmanager. As WFO feature is handled by rdk-wanmanager, we are moving this flag creation to rdk-wanmanager Yocto recipe.

Risks: Low
Test Procedure: None
Signed-off-by: Aiswarya Prasad <aprasad@maxlinear.com>
