### PR TITLE
SHARMAN-3449 : Global ipv6 PD updated on erouter0 instead of brlan0.

### DIFF
--- a/recipes-ccsp/ccsp/rdk-wanmanager.bb
+++ b/recipes-ccsp/ccsp/rdk-wanmanager.bb
@@ -8,7 +8,7 @@ DEPENDS_append = " ${@bb.utils.contains('DISTRO_FEATURES', 'rdkb_wan_manager', '
 
 require recipes-ccsp/ccsp/ccsp_common.inc
 
-GIT_TAG = "v2.7.1"
+GIT_TAG = "v2.7.2"
 SRC_URI := "git://github.com/rdkcentral/RdkWanManager.git;branch=releases/2.7.0-main;protocol=https;name=WanManager;tag=${GIT_TAG}"
 PV = "${GIT_TAG}+git${SRCPV}"
 


### PR DESCRIPTION
Reason for change:
Replcaing bridge_mode sysevent query with TR181 DML

Creating a v1.7.2 tag for this change.

Test Procedure:
Updated in Jira.

Risks: none
Priority: P1